### PR TITLE
refactor: scripts, utils, logger

### DIFF
--- a/src/script.ts
+++ b/src/script.ts
@@ -1,9 +1,17 @@
+import { env } from 'node:process';
 import kleur from 'kleur';
 import type { Script, ScriptContext } from 'types';
 import { log } from './logger';
-import { extractCommands, stopwatch } from './utils';
+import { stopwatch } from './utils';
 
-const commands = extractCommands();
+const cmds = [] as string[];
+for (const key in env) {
+  if (/^npm_package_scripts_.+/.test(key)) {
+    cmds.push(key
+      .replace(/^npm_package_scripts_/, '')
+      .replace(/_/g, '-'));
+  }
+}
 
 function init(ctx: ScriptContext): Script {
   return ((cmd, callback) => {
@@ -17,9 +25,7 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
   const colored = kleur.blue(cmd);
 
   log(`Running ${colored} ...`);
-  if (!commands.includes(cmd)) {
-    log.warn(`${colored} not found in package.json`);
-  }
+  if (!cmds.includes(cmd)) log.warn(`${colored} not found in package.json`);
 
   const callback = ctx.scripts[cmd];
   if (!callback) {

--- a/src/script.ts
+++ b/src/script.ts
@@ -16,7 +16,6 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
   if (ctx.rejected.length) return;
   const colored = kleur.blue(cmd);
 
-  ctx.running.add(cmd);
   log(`Running ${colored} ...`);
   if (!commands.includes(cmd)) {
     log.warn(`${colored} not found in package.json`);
@@ -24,25 +23,20 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
 
   const callback = ctx.scripts[cmd];
   if (!callback) {
-    ctx.running.delete(cmd);
     ctx.rejected.push(cmd);
     log.error.trace(`${colored} is not described or has no callback`);
-    if (!ctx.running.size) log.empty();
     return;
   }
 
   await callback();
-  ctx.running.delete(cmd);
   log[ctx.rejected.length
     ? 'error'
     : 'done'](`Finished ${colored} after ${lap()}`);
-  if (!ctx.running.size) log.empty();
 }
 
 function create(): Script {
   const ctx: ScriptContext = {
     rejected: [],
-    running: new Set<string>(),
     scripts: {},
   };
   const script = init(ctx);

--- a/src/script.ts
+++ b/src/script.ts
@@ -1,52 +1,42 @@
 import kleur from 'kleur';
 import type { Script, ScriptContext } from 'types';
 import { log } from './logger';
-import { extractCommands, isAsync, stopwatch } from './utils';
+import { extractCommands, stopwatch } from './utils';
 
 const commands = extractCommands();
 
 function init(ctx: ScriptContext): Script {
   return ((cmd, callback) => {
-    ctx.scripts[cmd] = callback;
+    ctx.scripts[cmd] = () => Promise.resolve(callback());
   }) as Script;
 }
 
-function runner(ctx: ScriptContext, cmd: string): Promise<unknown> {
-  return new Promise((resolve) => {
-    const { lap } = stopwatch();
-    if (ctx.rejected.size) return;
-    const colored = kleur.blue(cmd);
+async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
+  const { lap } = stopwatch();
+  if (ctx.rejected.size) return;
+  const colored = kleur.blue(cmd);
 
-    ctx.running.add(cmd);
-    log(`Running ${colored} ...`);
-    if (!commands.includes(cmd)) {
-      log.warn(`${colored} not found in package.json`);
-    }
+  ctx.running.add(cmd);
+  log(`Running ${colored} ...`);
+  if (!commands.includes(cmd)) {
+    log.warn(`${colored} not found in package.json`);
+  }
 
-    const callback = ctx.scripts[cmd];
-    if (!callback) {
-      ctx.running.delete(cmd);
-      ctx.rejected.add(cmd);
-      log.error.trace(`${colored} is not described or has no callback`);
-      if (!ctx.running.size) log.empty();
-      return;
-    }
+  const callback = ctx.scripts[cmd];
+  if (!callback) {
+    ctx.running.delete(cmd);
+    ctx.rejected.add(cmd);
+    log.error.trace(`${colored} is not described or has no callback`);
+    if (!ctx.running.size) log.empty();
+    return;
+  }
 
-    const done = (returns: unknown): void => {
-      ctx.running.delete(cmd);
-      log[ctx.rejected.size
-        ? 'error'
-        : 'done'](`Finished ${colored} after ${lap()}`);
-      if (!ctx.running.size) log.empty();
-      resolve(returns);
-    };
-    const returns = callback();
-    if (isAsync(callback, returns)) {
-      (returns as Promise<unknown>).then(done);
-      return;
-    }
-    done(returns);
-  });
+  await callback();
+  ctx.running.delete(cmd);
+  log[ctx.rejected.size
+    ? 'error'
+    : 'done'](`Finished ${colored} after ${lap()}`);
+  if (!ctx.running.size) log.empty();
 }
 
 function create(): Script {

--- a/src/script.ts
+++ b/src/script.ts
@@ -13,7 +13,7 @@ function init(ctx: ScriptContext): Script {
 
 async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
   const { lap } = stopwatch();
-  if (ctx.rejected.size) return;
+  if (ctx.rejected.length) return;
   const colored = kleur.blue(cmd);
 
   ctx.running.add(cmd);
@@ -25,7 +25,7 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
   const callback = ctx.scripts[cmd];
   if (!callback) {
     ctx.running.delete(cmd);
-    ctx.rejected.add(cmd);
+    ctx.rejected.push(cmd);
     log.error.trace(`${colored} is not described or has no callback`);
     if (!ctx.running.size) log.empty();
     return;
@@ -33,7 +33,7 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
 
   await callback();
   ctx.running.delete(cmd);
-  log[ctx.rejected.size
+  log[ctx.rejected.length
     ? 'error'
     : 'done'](`Finished ${colored} after ${lap()}`);
   if (!ctx.running.size) log.empty();
@@ -41,7 +41,7 @@ async function runner(ctx: ScriptContext, cmd: string): Promise<void> {
 
 function create(): Script {
   const ctx: ScriptContext = {
-    rejected: new Set<string>(),
+    rejected: [],
     running: new Set<string>(),
     scripts: {},
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,16 +1,16 @@
 import { env, hrtime } from 'node:process';
 import type { Stopwatch, TraceReturns } from 'types';
 
-function extractEvents(): string[] {
-  const events = [];
+function extractCommands(): string[] {
+  const commands = [];
   for (const key in env) {
     if (/^npm_package_scripts_.+/.test(key)) {
-      events.push(key
+      commands.push(key
         .replace(/^npm_package_scripts_/, '')
         .replace(/_/g, '-'));
     }
   }
-  return events;
+  return commands;
 }
 
 const AsyncConstructor = (async () => {}).constructor;
@@ -61,7 +61,7 @@ function trace(error: Error): TraceReturns {
 }
 
 export {
-  extractEvents,
+  extractCommands,
   isAsync,
   stopwatch,
   time,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,17 +1,5 @@
-import { env, hrtime } from 'node:process';
-import type { Stopwatch, TraceReturns } from 'types';
-
-function extractCommands(): string[] {
-  const commands = [];
-  for (const key in env) {
-    if (/^npm_package_scripts_.+/.test(key)) {
-      commands.push(key
-        .replace(/^npm_package_scripts_/, '')
-        .replace(/_/g, '-'));
-    }
-  }
-  return commands;
-}
+import { hrtime } from 'node:process';
+import type { Stopwatch } from 'types';
 
 function stopwatch(): Stopwatch {
   let start: number;
@@ -23,37 +11,6 @@ function stopwatch(): Stopwatch {
   return inner();
 }
 
-const formatter = new Intl.DateTimeFormat('en-us', {
-  hour: 'numeric',
-  minute: 'numeric',
-  second: 'numeric',
-  fractionalSecondDigits: 3,
-  hour12: false,
-});
-function time(): string {
-  return formatter.format(Date.now());
-}
-
-function trace(error: Error): TraceReturns {
-  function done(path?: string): TraceReturns {
-    return {
-      ...path ? { path } : {},
-      message: error.message,
-    };
-  }
-  if (!error.stack) return done();
-  const [,,,, file] = error.stack.split('\n');
-  if (!file) return done();
-  const matched = file.match(/file:\/\/(.+)/);
-  if (!matched) return done();
-  const [, path] = matched;
-  if (!path) return done();
-  return done(path);
-}
-
 export {
-  extractCommands,
   stopwatch,
-  time,
-  trace,
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,15 +13,6 @@ function extractCommands(): string[] {
   return commands;
 }
 
-const AsyncConstructor = (async () => {}).constructor;
-function isAsync(fn: unknown, returns: unknown): boolean {
-  return !!(fn instanceof AsyncConstructor
-    || (typeof fn === 'function'
-      && !!(typeof returns === 'object'
-        && typeof (returns as Record<string, unknown>)['then']
-          === 'function')));
-}
-
 function stopwatch(): Stopwatch {
   let start: number;
   function inner(): Stopwatch {
@@ -62,7 +53,6 @@ function trace(error: Error): TraceReturns {
 
 export {
   extractCommands,
-  isAsync,
   stopwatch,
   time,
   trace,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,6 @@ interface Script {
 }
 interface ScriptContext {
   rejected: string[];
-  running: Set<string>;
   scripts: Record<string, () => Promise<unknown>>;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ interface Script {
   run(cmd?: string): Promise<void>;
 }
 interface ScriptContext {
-  rejected: Set<string>;
+  rejected: string[];
   running: Set<string>;
   scripts: Record<string, () => Promise<unknown>>;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,14 +1,16 @@
 declare type LoggerTypes = 'done' | 'error' | 'warn';
 
 interface Script {
-  <T extends unknown>(cmd: string, callback: ScriptCallback<T>): void;
-  run(cmd?: string): Promise<unknown>;
+  <T extends unknown>(
+    cmd: string,
+    callback: (() => T) | (() => Promise<T>),
+  ): void;
+  run(cmd?: string): Promise<void>;
 }
-declare type ScriptCallback<T> = (() => T) | (() => Promise<T>);
 interface ScriptContext {
   rejected: Set<string>;
   running: Set<string>;
-  scripts: Record<string, ScriptCallback<unknown>>;
+  scripts: Record<string, () => Promise<unknown>>;
 }
 
 interface Stopwatch {
@@ -23,7 +25,6 @@ declare type TraceReturns = {
 export {
   LoggerTypes,
   Script,
-  ScriptCallback,
   ScriptContext,
   Stopwatch,
   TraceReturns,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,7 +8,7 @@ declare type ScriptCallback<T> = (() => T) | (() => Promise<T>);
 interface ScriptContext {
   rejected: Set<string>;
   running: Set<string>;
-  scripts: Map<string, ScriptCallback<unknown>>;
+  scripts: Record<string, ScriptCallback<unknown>>;
 }
 
 interface Stopwatch {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,7 @@
+declare type LoggerTraceReturns = {
+  message: string;
+  path?: string;
+};
 declare type LoggerTypes = 'done' | 'error' | 'warn';
 
 interface Script {
@@ -16,15 +20,11 @@ interface Stopwatch {
   (): Stopwatch;
   lap(): string;
 }
-declare type TraceReturns = {
-  message: string;
-  path?: string;
-};
 
 export {
+  LoggerTraceReturns,
   LoggerTypes,
   Script,
   ScriptContext,
   Stopwatch,
-  TraceReturns,
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,8 +1,8 @@
 declare type LoggerTypes = 'done' | 'error' | 'warn';
 
 interface Script {
-  <T extends unknown>(event: string, callback: ScriptCallback<T>): void;
-  run(event?: string): Promise<unknown>;
+  <T extends unknown>(cmd: string, callback: ScriptCallback<T>): void;
+  run(cmd?: string): Promise<unknown>;
 }
 declare type ScriptCallback<T> = (() => T) | (() => Promise<T>);
 interface ScriptContext {


### PR DESCRIPTION
- refactor: rename event to cmd
- refactor: change map to obj for ctx.scripts
- refactor: force conversion callback to async
- refactor: change set to arr for ctx.rejected
- refactor: remove running from ctx
- refactor: rm unused isAsync
- refactor: merge utils
